### PR TITLE
Revamp support for long windows

### DIFF
--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -15,7 +15,6 @@
       <option name="ignoredIdentifiers">
         <list>
           <option value="numpy.core.multiarray.ndarray.__getitem__" />
-          <option value="scipy.signal.gaussian" />
         </list>
       </option>
     </inspection_tool>

--- a/ovgenpy/channel.py
+++ b/ovgenpy/channel.py
@@ -48,18 +48,12 @@ class Channel:
         del subsampling
         del nsamp
 
-        # FIXME unit test
-        frame_time = (1 / ovgen_cfg.fps)
-        tsamp_frame = self.time2tsamp(frame_time)
-
         # Create a Trigger object.
         tcfg = cfg.trigger or ovgen_cfg.trigger
         self.trigger = tcfg(
             wave=self.wave,
             nsamp=self.nsamp,
             subsampling=self.trigger_subsampling,
-            nsamp_frame=tsamp_frame
+            fps=ovgen_cfg.fps
         )
 
-    def time2tsamp(self, time: float):
-        return round(time * self.wave.smp_s / self.trigger_subsampling)

--- a/ovgenpy/channel.py
+++ b/ovgenpy/channel.py
@@ -41,15 +41,16 @@ class Channel:
         self.trigger_subsampling = subsampling * cfg.trigger_width_ratio
         self.render_subsampling = subsampling * cfg.render_width_ratio
 
-        # Compute nsamp and nsamp_frame.
+        # Compute nsamp and tsamp_frame.
         nsamp = ovgen_cfg.render_width_s * self.wave.smp_s / subsampling
         self.nsamp = round(nsamp)
 
         del subsampling
         del nsamp
 
-        nsamp_frame = (1 / ovgen_cfg.fps) * self.wave.smp_s
-        nsamp_frame = round(nsamp_frame)
+        # FIXME unit test
+        frame_time = (1 / ovgen_cfg.fps)
+        tsamp_frame = self.time2tsamp(frame_time)
 
         # Create a Trigger object.
         tcfg = cfg.trigger or ovgen_cfg.trigger
@@ -57,6 +58,8 @@ class Channel:
             wave=self.wave,
             nsamp=self.nsamp,
             subsampling=self.trigger_subsampling,
-            nsamp_frame=nsamp_frame
+            nsamp_frame=tsamp_frame
         )
 
+    def time2tsamp(self, time: float):
+        return round(time * self.wave.smp_s / self.trigger_subsampling)

--- a/ovgenpy/channel.py
+++ b/ovgenpy/channel.py
@@ -37,21 +37,26 @@ class Channel:
         wcfg = _WaveConfig(amplification=ovgen_cfg.amplification * cfg.ampl_ratio)
         self.wave = Wave(wcfg, cfg.wav_path)
 
-        # Compute nsamp.
-        nsamp = ovgen_cfg.render_width_s * self.wave.smp_s / subsampling
-        self.nsamp = round(nsamp)
-        del nsamp
-
         # Compute subsampling (array stride).
         self.trigger_subsampling = subsampling * cfg.trigger_width_ratio
         self.render_subsampling = subsampling * cfg.render_width_ratio
+
+        # Compute nsamp and nsamp_frame.
+        nsamp = ovgen_cfg.render_width_s * self.wave.smp_s / subsampling
+        self.nsamp = round(nsamp)
+
         del subsampling
+        del nsamp
+
+        nsamp_frame = (1 / ovgen_cfg.fps) * self.wave.smp_s
+        nsamp_frame = round(nsamp_frame)
 
         # Create a Trigger object.
         tcfg = cfg.trigger or ovgen_cfg.trigger
         self.trigger = tcfg(
             wave=self.wave,
             nsamp=self.nsamp,
-            subsampling=self.trigger_subsampling
+            subsampling=self.trigger_subsampling,
+            nsamp_frame=nsamp_frame
         )
 

--- a/ovgenpy/channel.py
+++ b/ovgenpy/channel.py
@@ -23,7 +23,7 @@ class ChannelConfig:
 
 class Channel:
     # Shared between trigger and renderer.
-    nsamp: int
+    window_samp: int
 
     # Product of ovgen_cfg.subsampling and trigger/render_width_ratio.
     trigger_subsampling: int
@@ -41,9 +41,9 @@ class Channel:
         self.trigger_subsampling = subsampling * cfg.trigger_width_ratio
         self.render_subsampling = subsampling * cfg.render_width_ratio
 
-        # Compute nsamp and tsamp_frame.
+        # Compute window_samp and tsamp_frame.
         nsamp = ovgen_cfg.render_width_s * self.wave.smp_s / subsampling
-        self.nsamp = round(nsamp)
+        self.window_samp = round(nsamp)
 
         del subsampling
         del nsamp
@@ -52,7 +52,7 @@ class Channel:
         tcfg = cfg.trigger or ovgen_cfg.trigger
         self.trigger = tcfg(
             wave=self.wave,
-            tsamp=self.nsamp,
+            tsamp=self.window_samp,
             subsampling=self.trigger_subsampling,
             fps=ovgen_cfg.fps
         )

--- a/ovgenpy/channel.py
+++ b/ovgenpy/channel.py
@@ -52,7 +52,7 @@ class Channel:
         tcfg = cfg.trigger or ovgen_cfg.trigger
         self.trigger = tcfg(
             wave=self.wave,
-            nsamp=self.nsamp,
+            tsamp=self.nsamp,
             subsampling=self.trigger_subsampling,
             fps=ovgen_cfg.fps
         )

--- a/ovgenpy/channel.py
+++ b/ovgenpy/channel.py
@@ -14,8 +14,9 @@ class ChannelConfig:
     wav_path: str
 
     trigger: 'ITriggerConfig' = None    # TODO test channel-specific triggers
-    trigger_width_ratio: int = 1
-    render_width_ratio: int = 1
+    # Multiplies how wide the window is, in milliseconds.
+    trigger_width: int = 1
+    render_width: int = 1
 
     ampl_ratio: float = 1.0     # TODO use amplification = None instead?
     line_color: Any = None
@@ -25,7 +26,7 @@ class Channel:
     # Shared between trigger and renderer.
     window_samp: int
 
-    # Product of ovgen_cfg.subsampling and trigger/render_width_ratio.
+    # Product of ovgen_cfg.subsampling and trigger/render_width.
     trigger_subsampling: int
     render_subsampling: int
 
@@ -38,8 +39,8 @@ class Channel:
         self.wave = Wave(wcfg, cfg.wav_path)
 
         # Compute subsampling (array stride).
-        self.trigger_subsampling = subsampling * cfg.trigger_width_ratio
-        self.render_subsampling = subsampling * cfg.render_width_ratio
+        self.trigger_subsampling = subsampling * cfg.trigger_width
+        self.render_subsampling = subsampling * cfg.render_width
 
         # Compute window_samp and tsamp_frame.
         nsamp = ovgen_cfg.render_width_s * self.wave.smp_s / subsampling

--- a/ovgenpy/cli.py
+++ b/ovgenpy/cli.py
@@ -155,12 +155,17 @@ def main(
             if profile:
                 import cProfile
 
+                # Pycharm can't load CProfile files with dots in the name.
+                profile_dump_name = Path(files[0]).name.split('.')[0]
+                profile_dump_name += f'-{PROFILE_DUMP_NAME}'
+
                 # Write stats to unused filename
                 for i in count():
-                    path = Path(PROFILE_DUMP_NAME + str(i))
+                    path = Path(profile_dump_name + str(i))
                     if not path.exists():
                         break
 
+                # noinspection PyUnboundLocalVariable
                 cProfile.runctx('Ovgen(cfg).play()', globals(), locals(), path)
 
             else:

--- a/ovgenpy/config.py
+++ b/ovgenpy/config.py
@@ -93,19 +93,21 @@ class _ConfigMixin:
         Then call the dataclass constructor (to validate parameters). """
 
         for key, value in dict(state).items():
-            classvar = getattr(self, key, None)
-            if not isinstance(classvar, Alias):
-                continue
+            class_var = getattr(self, key, None)
 
-            target = classvar.key
-            if target in state:
-                raise TypeError(
-                    f'{type(self).__name__} received both Alias {key} and equivalent '
-                    f'{target}'
-                )
+            if class_var is Ignored:
+                del state[key]
 
-            state[target] = value
-            del state[key]
+            if isinstance(class_var, Alias):
+                target = class_var.key
+                if target in state:
+                    raise TypeError(
+                        f'{type(self).__name__} received both Alias {key} and '
+                        f'equivalent {target}'
+                    )
+
+                state[target] = value
+                del state[key]
 
         obj = type(self)(**state)
         self.__dict__ = obj.__dict__
@@ -121,6 +123,8 @@ class Alias:
     """
     key: str
 
+
+Ignored = object()
 
 # Unused
 def default(value):

--- a/ovgenpy/config.py
+++ b/ovgenpy/config.py
@@ -1,7 +1,7 @@
 from io import StringIO
 from typing import ClassVar, TYPE_CHECKING
 
-from ovgenpy.utils.keyword_dataclasses import dataclass, fields
+from ovgenpy.utils.keyword_dataclasses import dataclass, fields, field
 # from dataclasses import dataclass, fields
 from ruamel.yaml import yaml_object, YAML, Representer
 
@@ -50,6 +50,12 @@ def register_config(cls=None, *, always_dump: str = ''):
         return decorator
 
     # __init__-less non-dataclasses are also compatible with yaml.register_class.
+
+
+# Default value for dataclass field
+def default(value):
+    string = repr(value)
+    return field(default=lambda: eval(string))
 
 
 @dataclass()

--- a/ovgenpy/config.py
+++ b/ovgenpy/config.py
@@ -8,6 +8,7 @@ from ruamel.yaml import yaml_object, YAML, Representer
 if TYPE_CHECKING:
     from enum import Enum
 
+# Setup YAML loading (yaml object).
 
 class MyYAML(YAML):
     def dump(self, data, stream=None, **kw):
@@ -28,10 +29,12 @@ yaml = MyYAML()
 _yaml_loadable = yaml_object(yaml)
 
 
+# Setup configuration load/dump infrastructure.
+
 def register_config(cls=None, *, always_dump: str = ''):
     """ Marks class as @dataclass, and enables YAML dumping (excludes default fields).
 
-    dataclasses.dataclass is compatible with yaml.register_class.
+    dataclasses.dataclass is compatible with yaml_object().
     typing.NamedTuple is incompatible.
     """
 
@@ -49,14 +52,6 @@ def register_config(cls=None, *, always_dump: str = ''):
     else:
         return decorator
 
-    # __init__-less non-dataclasses are also compatible with yaml.register_class.
-
-
-# Default value for dataclass field
-def default(value):
-    string = repr(value)
-    return field(default=lambda: eval(string))
-
 
 @dataclass()
 class _ConfigMixin:
@@ -69,7 +64,7 @@ class _ConfigMixin:
 
     # SafeRepresenter.represent_yaml_object() uses __getstate__ to dump objects.
     def __getstate__(self):
-        """ Returns all fields with non-default value, or appeear in
+        """ Removes all fields with default values, but not found in
         self.always_dump. """
 
         always_dump = set(self.always_dump.split())
@@ -94,10 +89,47 @@ class _ConfigMixin:
 
     # SafeConstructor.construct_yaml_object() uses __setstate__ to load objects.
     def __setstate__(self, state):
-        """Call the dataclass constructor, to ensure all parameters are valid."""
-        new = type(self)(**state)
-        self.__dict__ = new.__dict__
+        """ Redirect `Alias(key)=value` to `key=value`.
+        Then call the dataclass constructor (to validate parameters). """
 
+        for key, value in dict(state).items():
+            classvar = getattr(self, key, None)
+            if not isinstance(classvar, Alias):
+                continue
+
+            target = classvar.key
+            if target in state:
+                raise TypeError(
+                    f'{type(self).__name__} received both Alias {key} and equivalent '
+                    f'{target}'
+                )
+
+            state[target] = value
+            del state[key]
+
+        obj = type(self)(**state)
+        self.__dict__ = obj.__dict__
+
+
+@dataclass
+class Alias:
+    """
+    @register_config
+    class Foo:
+        x: int
+        xx = Alias('x')     # do not add a type hint
+    """
+    key: str
+
+
+# Unused
+def default(value):
+    """Supplies a mutable default value for a dataclass field."""
+    string = repr(value)
+    return field(default=lambda: eval(string))
+
+
+# Setup Enum load/dump infrastructure
 
 def register_enum(cls: type):
     cls.to_yaml = _EnumMixin.to_yaml
@@ -109,6 +141,8 @@ class _EnumMixin:
     def to_yaml(cls, representer: Representer, node: 'Enum'):
         return representer.represent_str(node._name_)
 
+
+# Miscellaneous
 
 class OvgenError(Exception):
     pass

--- a/ovgenpy/config.py
+++ b/ovgenpy/config.py
@@ -127,10 +127,10 @@ class Alias:
 Ignored = object()
 
 # Unused
-def default(value):
-    """Supplies a mutable default value for a dataclass field."""
-    string = repr(value)
-    return field(default=lambda: eval(string))
+# def default(value):
+#     """Supplies a mutable default value for a dataclass field."""
+#     string = repr(value)
+#     return field(default_factory=lambda: eval(string))
 
 
 # Setup Enum load/dump infrastructure

--- a/ovgenpy/ovgenpy.py
+++ b/ovgenpy/ovgenpy.py
@@ -6,7 +6,7 @@ from typing import Optional, List, Union, TYPE_CHECKING
 
 from ovgenpy import outputs
 from ovgenpy.channel import Channel, ChannelConfig
-from ovgenpy.config import register_config, register_enum
+from ovgenpy.config import register_config, register_enum, Ignored
 from ovgenpy.renderer import MatplotlibRenderer, RendererConfig, LayoutConfig
 from ovgenpy.triggers import ITriggerConfig, CorrelationTriggerConfig
 from ovgenpy.utils import keyword_dataclasses as dc
@@ -49,6 +49,10 @@ class Config:
 
     show_buffer: bool = False
     benchmark_mode: Union[str, BenchmarkMode] = BenchmarkMode.NONE
+
+    # region Legacy Fields
+    wav_prefix = Ignored
+    # endregion
 
     @property
     def render_width_s(self) -> float:

--- a/ovgenpy/ovgenpy.py
+++ b/ovgenpy/ovgenpy.py
@@ -35,11 +35,11 @@ class Config:
     fps: int
     begin_time: float = 0
 
-    channels: List[ChannelConfig] = field(default_factory=list)
+    subsampling: int
 
     width_ms: int
-    subsampling: int
-    trigger: ITriggerConfig  # Maybe overriden per Wave
+    channels: List[ChannelConfig] = field(default_factory=list)
+    trigger: ITriggerConfig  # Can be overriden per Wave
 
     amplification: float
     layout: LayoutConfig

--- a/ovgenpy/ovgenpy.py
+++ b/ovgenpy/ovgenpy.py
@@ -178,7 +178,7 @@ class Ovgen:
                         trigger_sample = sample
 
                     datas.append(wave.get_around(
-                        trigger_sample, channel.nsamp, channel.render_subsampling))
+                        trigger_sample, channel.window_samp, channel.render_subsampling))
 
                 # Display buffers, for debugging purposes.
                 if show_buffer:

--- a/ovgenpy/ovgenpy.py
+++ b/ovgenpy/ovgenpy.py
@@ -76,13 +76,7 @@ def default_config(**kwargs):
 
         width_ms=25,
         subsampling=1,
-        trigger=CorrelationTriggerConfig(
-            trigger_strength=10,
-            use_edge_trigger=True,
-
-            responsiveness=0.1,
-            falloff_width=0.5,
-        ),
+        trigger=CorrelationTriggerConfig(),
 
         amplification=1,
         layout=LayoutConfig(ncols=1),
@@ -189,7 +183,7 @@ class Ovgen:
                 # Display buffers, for debugging purposes.
                 if show_buffer:
                     triggers: List['CorrelationTrigger'] = self.triggers
-                    buf_render.render_frame([trigger._buffer for trigger in triggers])
+                    buf_render.render_frame([trigger.lol for trigger in triggers])
                     buf_output.write_frame(buf_render.get_frame())
 
                 if not_benchmarking or benchmark_mode >= BenchmarkMode.RENDER:

--- a/ovgenpy/ovgenpy.py
+++ b/ovgenpy/ovgenpy.py
@@ -183,7 +183,7 @@ class Ovgen:
                 # Display buffers, for debugging purposes.
                 if show_buffer:
                     triggers: List['CorrelationTrigger'] = self.triggers
-                    buf_render.render_frame([trigger.lol for trigger in triggers])
+                    buf_render.render_frame([trigger._buffer for trigger in triggers])
                     buf_output.write_frame(buf_render.get_frame())
 
                 if not_benchmarking or benchmark_mode >= BenchmarkMode.RENDER:

--- a/ovgenpy/ovgenpy.py
+++ b/ovgenpy/ovgenpy.py
@@ -36,11 +36,15 @@ class Config:
     fps: int
     begin_time: float = 0
 
-    subsampling: int
+    subsampling: int    # TODO optional=1
 
     width_ms: int
-    channels: List[ChannelConfig] = field(default_factory=list)
+    trigger_width: int = 1
+    render_width: int = 1
     trigger: ITriggerConfig  # Can be overriden per Wave
+
+    # Can override trigger_width, render_width, trigger
+    channels: List[ChannelConfig] = field(default_factory=list)
 
     amplification: float
     layout: LayoutConfig

--- a/ovgenpy/triggers.py
+++ b/ovgenpy/triggers.py
@@ -5,7 +5,7 @@ import numpy as np
 from scipy import signal
 from scipy.signal import windows
 
-from ovgenpy.config import register_config, OvgenError
+from ovgenpy.config import register_config, OvgenError, Alias
 from ovgenpy.util import find
 from ovgenpy.utils.windows import midpad, leftpad
 from ovgenpy.wave import FLOAT
@@ -72,6 +72,11 @@ class CorrelationTriggerConfig(ITriggerConfig):
     # _update_buffer
     responsiveness: float = 0.1
     buffer_falloff: float = 0.5
+
+    # region Legacy Aliases
+    trigger_strength = Alias('edge_strength')
+    falloff_width = Alias('buffer_falloff')
+    # endregion
 
 
 @register_trigger(CorrelationTriggerConfig)

--- a/ovgenpy/triggers.py
+++ b/ovgenpy/triggers.py
@@ -296,7 +296,7 @@ def get_period(data: np.ndarray) -> int:
 
     crossX = zero_crossings[0]
     peakX = crossX + np.argmax(corr[crossX:])
-    return peakX
+    return int(peakX)
 
 
 def cosine_flat(n: int, diameter: int, falloff: int):

--- a/ovgenpy/triggers.py
+++ b/ovgenpy/triggers.py
@@ -105,11 +105,14 @@ class CorrelationTrigger(Trigger):
             fps=self._fps
         )
 
-        # Precompute tables
+        # Precompute edge trigger step
         self._windowed_step = self._calc_step()
 
         # Input data taper (zeroes out all data older than 1 frame old)
         self._data_taper = self._calc_data_taper()  # Rejected idea: right cosine taper
+
+        # For debug output
+        self.save_window = False
 
     def _calc_step(self):
         """ Step function used for approximate edge triggering. """
@@ -140,6 +143,7 @@ class CorrelationTrigger(Trigger):
         # Generate left half-taper to prevent correlating with 1-frame-old data.
         data_window = np.ones(N)
         data_window[:halfN] = np.minimum(data_window[:halfN], taper)
+
         return data_window
 
     def get_trigger(self, index: int) -> int:
@@ -160,6 +164,9 @@ class CorrelationTrigger(Trigger):
 
         window = np.minimum(falloff_window, self._data_taper)
         data *= window
+
+        if self.save_window:
+            self._prev_window = window
 
         # prev_buffer
         prev_buffer = self._windowed_step + self._buffer

--- a/ovgenpy/triggers.py
+++ b/ovgenpy/triggers.py
@@ -55,10 +55,11 @@ class Trigger(ABC):
 
 # CorrelationTrigger
 
-@register_config
+@register_config(always_dump='*')
 class CorrelationTriggerConfig(ITriggerConfig):
     # get_trigger
     trigger_strength: float
+    trigger_diameter: float = 0.5
     use_edge_trigger: bool
 
     # _update_buffer
@@ -168,7 +169,7 @@ class CorrelationTrigger(Trigger):
 
         # Find optimal offset (within ±N//4)
         mid = N-1
-        radius = N//4
+        radius = round(N * self.cfg.trigger_diameter / 2)
 
         left = mid - radius
         right = mid + radius + 1

--- a/ovgenpy/triggers.py
+++ b/ovgenpy/triggers.py
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
 
 # Abstract classes
 
-# TODO rename nsamp to trigger_nsamp or tsamp or wsamp
+# FIXME rename nsamp to trigger_nsamp or tsamp
 class ITriggerConfig:
     cls: Type['Trigger']
 
@@ -39,6 +39,7 @@ def register_trigger(config_t: Type[ITriggerConfig]):
 class Trigger(ABC):
     def __init__(self, wave: 'Wave', cfg: ITriggerConfig, nsamp: int, subsampling: int,
                  nsamp_frame: int):
+        # FIXME replace nsamp_frame with frame_time, add _time2tsamp() method
         self.cfg = cfg
         self._wave = wave
 

--- a/ovgenpy/triggers.py
+++ b/ovgenpy/triggers.py
@@ -147,13 +147,11 @@ class CorrelationTrigger(Trigger):
 
         # Window data
         period = get_period(data)
-        print(period)
         diameter, falloff = [round(period * x) for x in self.cfg.trigger_falloff]
         falloff_window = cosine_flat(N, diameter, falloff)
 
         window = np.minimum(falloff_window, self._data_taper)
         data *= window
-        self.lol = window
 
         # prev_buffer
         prev_buffer = self._windowed_step + self._buffer

--- a/ovgenpy/triggers.py
+++ b/ovgenpy/triggers.py
@@ -233,14 +233,14 @@ class CorrelationTrigger(Trigger):
 
         # Update correlation buffer (distinct from visible area)
         aligned = self._wave.get_around(trigger, self._buffer_nsamp, self._subsampling)
-        self._update_buffer(aligned)
+        self._update_buffer(aligned, period)
 
         if use_edge_trigger:
             return self._zero_trigger.get_trigger(trigger)
         else:
             return trigger
 
-    def _update_buffer(self, data: np.ndarray) -> None:
+    def _update_buffer(self, data: np.ndarray, wave_period: int) -> None:
         """
         Update self._buffer by adding `data` and a step function.
         Data is reshaped to taper away from the center.
@@ -257,8 +257,6 @@ class CorrelationTrigger(Trigger):
 
         # New waveform
         self._normalize_buffer(data)
-
-        wave_period = get_period(data)
         window = windows.gaussian(N, std = wave_period * buffer_falloff)
         data *= window
 

--- a/ovgenpy/triggers.py
+++ b/ovgenpy/triggers.py
@@ -64,14 +64,20 @@ class Trigger(ABC):
 
 # CorrelationTrigger
 
-@register_config(always_dump='*')
+@register_config(always_dump='''
+    use_edge_trigger
+    edge_strength
+    responsiveness
+    buffer_falloff
+''')
 class CorrelationTriggerConfig(ITriggerConfig):
     # get_trigger
-    edge_strength: float = 10
-    lag_prevention: float = 0.25
-    trigger_diameter: float = 0.5
-    trigger_falloff: Tuple[float, float] = (4, 1)
     use_edge_trigger: bool = True
+    edge_strength: float = 10.0
+    trigger_diameter: float = 0.5
+
+    trigger_falloff: Tuple[float, float] = (4.0, 1.0)
+    lag_prevention: float = 0.25
 
     # _update_buffer
     responsiveness: float = 0.1

--- a/ovgenpy/triggers.py
+++ b/ovgenpy/triggers.py
@@ -128,7 +128,12 @@ class CorrelationTrigger(Trigger):
         assert len(taper) == halfN
 
         # Generate Gaussian window based on data width.
-        data_window = windows.gaussian(N, std=halfN / self._subsampling)
+
+        # FIXME: If subsampling doubles, halfN *2 and _subsampling *2. data_window
+        # should /2, but would previously / 2√2.
+        # (Note: data_window(std=) is in units of samples, whose size is proportional
+        # to _subsampling.)
+        data_window = windows.gaussian(N, std=halfN)    # / self._subsampling)
 
         # Truncate left half of data_window (don't correlate with data 1+ frames old).
         data_window[:halfN] = np.minimum(data_window[:halfN], taper)

--- a/ovgenpy/triggers.py
+++ b/ovgenpy/triggers.py
@@ -82,6 +82,18 @@ class CorrelationTriggerConfig(ITriggerConfig):
     falloff_width = Alias('buffer_falloff')
     # endregion
 
+    def __post_init__(self):
+        self._validate_param('lag_prevention', 0, 1)
+        self._validate_param('responsiveness', 0, 1)
+        # TODO trigger_falloff >= 0
+        self._validate_param('buffer_falloff', 0, np.inf)
+
+    def _validate_param(self, key: str, begin, end):
+        value = getattr(self, key)
+        if not begin <= value <= end:
+            raise ValueError(
+                f'Invalid {key}={value} (should be within [{begin}, {end}])')
+
 
 @register_trigger(CorrelationTriggerConfig)
 class CorrelationTrigger(Trigger):

--- a/ovgenpy/triggers.py
+++ b/ovgenpy/triggers.py
@@ -7,6 +7,7 @@ from scipy.signal import windows
 
 from ovgenpy.config import register_config, OvgenError
 from ovgenpy.util import find
+from ovgenpy.utils.windows import midpad, leftpad
 from ovgenpy.wave import FLOAT
 
 
@@ -125,9 +126,7 @@ class CorrelationTrigger(Trigger):
         taper = windows.hann(nsamp_frame * 2)[:nsamp_frame]
 
         # Reshape taper to left `halfN` of data_window (right-aligned).
-        taper = taper[-halfN:]
-        taper = np.pad(taper, (halfN - len(taper), 0), 'constant')
-        assert len(taper) == halfN
+        taper = leftpad(taper, halfN)
 
         # Generate left half-taper to prevent correlating with 1-frame-old data.
         data_window = np.ones(N)
@@ -259,19 +258,8 @@ def cosine_flat(n: int, diameter: int, falloff: int):
 
     window = np.concatenate([left, np.ones(diameter), right])
 
-    oversize = len(window) - n
-    if oversize > 0:
-        half = oversize // 2
-        window = window[half: oversize - half]
-    del oversize
-
-    undersize = n - len(window)
-    if undersize > 0:
-        half = undersize // 2
-        window = np.pad(window, (half, undersize - half), 'constant')
-    del undersize
-
-    return window
+    padded = midpad(window, n)
+    return padded
 
 
 def lerp(x: np.ndarray, y: np.ndarray, a: float):

--- a/ovgenpy/utils/windows.py
+++ b/ovgenpy/utils/windows.py
@@ -1,0 +1,30 @@
+import numpy as np
+
+
+def leftpad(data: np.ndarray, n: int):
+    if not n > 0:
+        raise ValueError(f'leftpad(n={n}) must be > 0')
+
+    data = data[-n:]
+    data = np.pad(data, (n - len(data), 0), 'constant')
+
+    return data
+
+
+def midpad(data: np.ndarray, n: int):
+    if not n > 0:
+        raise ValueError(f'midpad(n={n}) must be > 0')
+
+    shrink = len(data) - n
+    if shrink > 0:
+        half = shrink // 2
+        data = data[half : -(shrink - half)]
+        return data
+
+    expand = n - len(data)
+    if expand > 0:
+        half = expand // 2
+        data = np.pad(data, (half, expand - half), 'constant')
+        return data
+
+    return data

--- a/tests/test_channel.py
+++ b/tests/test_channel.py
@@ -22,7 +22,7 @@ def test_channel_subsampling(
     render_width_ratio: int,
     mocker: MockFixture
 ):
-    """ Ensure nsamp and trigger/render subsampling are computed correctly. """
+    """ Ensure window_samp and trigger/render subsampling are computed correctly. """
 
     ovgenpy.ovgenpy.PRINT_TIMESTAMP = False    # Cleanup Hypothesis testing logs
 
@@ -50,34 +50,34 @@ def test_channel_subsampling(
     )
     channel = Channel(ccfg, cfg)
 
-    # Ensure channel.nsamp, trigger_subsampling, render_subsampling are correct.
+    # Ensure channel.window_samp, trigger_subsampling, render_subsampling are correct.
     ideal_nsamp = pytest.approx(
         round(cfg.render_width_s * channel.wave.smp_s / subsampling), 1)
 
-    assert channel.nsamp == ideal_nsamp
+    assert channel.window_samp == ideal_nsamp
     assert channel.trigger_subsampling == subsampling * trigger_width_ratio
     assert channel.render_subsampling == subsampling * render_width_ratio
 
-    # Ensure trigger uses channel.nsamp and trigger_subsampling.
+    # Ensure trigger uses channel.window_samp and trigger_subsampling.
     trigger = channel.trigger
-    assert trigger._nsamp == channel.nsamp
+    assert trigger._tsamp == channel.window_samp
     assert trigger._subsampling == channel.trigger_subsampling
 
-    # Ensure ovgenpy calls render using channel.nsamp and render_subsampling.
+    # Ensure ovgenpy calls render using channel.window_samp and render_subsampling.
     ovgen = Ovgen(cfg)
     renderer = mocker.patch.object(Ovgen, '_load_renderer').return_value
     ovgen.play()
 
     # Inspect arguments to wave.get_around()
     (_sample, _region_nsamp, _subsampling), kwargs = wave.get_around.call_args
-    assert _region_nsamp == channel.nsamp
+    assert _region_nsamp == channel.window_samp
     assert _subsampling == channel.render_subsampling
 
     # Inspect arguments to renderer.render_frame()
     # datas: List[np.ndarray]
     (datas,), kwargs = renderer.render_frame.call_args
     render_data = datas[0]
-    assert len(render_data) == channel.nsamp
+    assert len(render_data) == channel.window_samp
 
 
 # line_color is tested in test_renderer.py

--- a/tests/test_channel.py
+++ b/tests/test_channel.py
@@ -15,11 +15,11 @@ assert reproduce_failure
 
 positive = integers(min_value=1, max_value=100)
 
-@given(subsampling=positive, trigger_width_ratio=positive, render_width_ratio=positive)
+@given(subsampling=positive, trigger_width=positive, render_width=positive)
 def test_channel_subsampling(
     subsampling: int,
-    trigger_width_ratio: int,
-    render_width_ratio: int,
+    trigger_width: int,
+    render_width: int,
     mocker: MockFixture
 ):
     """ Ensure window_samp and trigger/render subsampling are computed correctly. """
@@ -38,8 +38,8 @@ def test_channel_subsampling(
 
     ccfg = ChannelConfig(
         'tests/sine440.wav',
-        trigger_width_ratio=trigger_width_ratio,
-        render_width_ratio=render_width_ratio,
+        trigger_width=trigger_width,
+        render_width=render_width,
     )
     cfg = default_config(
         channels=[ccfg],
@@ -55,8 +55,8 @@ def test_channel_subsampling(
         round(cfg.render_width_s * channel.wave.smp_s / subsampling), 1)
 
     assert channel.window_samp == ideal_nsamp
-    assert channel.trigger_subsampling == subsampling * trigger_width_ratio
-    assert channel.render_subsampling == subsampling * render_width_ratio
+    assert channel.trigger_subsampling == subsampling * trigger_width
+    assert channel.render_subsampling == subsampling * render_width
 
     # Ensure trigger uses channel.window_samp and trigger_subsampling.
     trigger = channel.trigger

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -4,10 +4,13 @@ import sys
 import pytest
 from ruamel.yaml import yaml_object
 
-from ovgenpy.config import register_config, yaml
+from ovgenpy.config import register_config, yaml, Alias
 
 
 # YAML Idiosyncrasies: https://docs.saltstack.com/en/develop/topics/troubleshooting/yaml_idiosyncrasies.html
+
+# Load/dump infrastructure testing
+from ovgenpy.utils.keyword_dataclasses import fields
 
 
 def test_register_config():
@@ -32,6 +35,8 @@ def test_yaml_object():
     s = yaml.dump(Bar())
     assert s == '!Bar {}\n'
 
+
+# Dataclass dump testing
 
 def test_dump_defaults():
     @register_config
@@ -71,7 +76,46 @@ b: b
 '''
 
 
-def test_argument_validation():
+# Dataclass load testing
+
+
+def test_dump_load_aliases():
+    """ Ensure dumping and loading `xx=Alias('x')` works.
+    Ensure loading `{x=1, xx=1}` raises an error.
+    Does not check constructor `Config(xx=1)`. """
+    @register_config
+    class Config:
+        x: int
+        xx = Alias('x')
+
+    # Test dumping
+    assert len(fields(Config)) == 1
+    cfg = Config(1)
+    s = yaml.dump(cfg)
+    assert s == '''\
+!Config
+x: 1
+'''
+    assert yaml.load(s) == cfg
+
+    # Test loading
+    s = '''\
+!Config
+xx: 1
+'''
+    assert yaml.load(s) == Config(x=1)
+
+    # Test exception on duplicated parameters.
+    s = '''\
+    !Config
+    x: 1
+    xx: 1
+    '''
+    with pytest.raises(TypeError):
+        yaml.load(s)
+
+
+def test_load_argument_validation():
     """ Ensure that loading config via YAML catches missing and invalid parameters. """
     @register_config
     class Config:
@@ -91,7 +135,6 @@ def test_argument_validation():
   a: 1
   b: 1
 ''')
-
 
 
 def test_load_post_init():

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -4,8 +4,7 @@ import sys
 import pytest
 from ruamel.yaml import yaml_object
 
-from ovgenpy.config import register_config, yaml, Alias
-
+from ovgenpy.config import register_config, yaml, Alias, Ignored
 
 # YAML Idiosyncrasies: https://docs.saltstack.com/en/develop/topics/troubleshooting/yaml_idiosyncrasies.html
 
@@ -82,7 +81,7 @@ b: b
 def test_dump_load_aliases():
     """ Ensure dumping and loading `xx=Alias('x')` works.
     Ensure loading `{x=1, xx=1}` raises an error.
-    Does not check constructor `Config(xx=1)`. """
+    Does not check constructor `Config(xx=1)`."""
     @register_config
     class Config:
         x: int
@@ -113,6 +112,31 @@ xx: 1
     '''
     with pytest.raises(TypeError):
         yaml.load(s)
+
+
+def test_dump_load_ignored():
+    """ Ensure loading `xx=Ignored` works.
+    Does not check constructor `Config(xx=1)`.
+    """
+    @register_config
+    class Config:
+        xx = Ignored
+
+    # Test dumping
+    assert len(fields(Config)) == 0
+    cfg = Config()
+    s = yaml.dump(cfg)
+    assert s == '''\
+!Config {}
+'''
+    assert yaml.load(s) == cfg
+
+    # Test loading
+    s = '''\
+!Config
+xx: 1
+'''
+    assert yaml.load(s) == Config()
 
 
 def test_load_argument_validation():

--- a/tests/test_trigger.py
+++ b/tests/test_trigger.py
@@ -4,7 +4,7 @@ from matplotlib.axes import Axes
 from matplotlib.figure import Figure
 
 from ovgenpy import triggers
-from ovgenpy.triggers import CorrelationTriggerConfig
+from ovgenpy.triggers import CorrelationTriggerConfig, CorrelationTrigger
 from ovgenpy.wave import Wave
 
 triggers.SHOW_TRIGGER = False
@@ -106,6 +106,29 @@ def test_trigger_subsampling_edges(cfg: CorrelationTriggerConfig):
     trigger.get_trigger(0)
     trigger.get_trigger(-1000)
     trigger.get_trigger(50000)
+
+
+def test_trigger_should_recalc_window():
+    cfg = CorrelationTriggerConfig(recalc_semitones=1.0)
+    wave = Wave(None, 'tests/sine440.wav')
+    trigger: CorrelationTrigger = cfg(wave, tsamp=1000, subsampling=1, fps=FPS)
+
+    for x in [0, 1, 1000]:
+        assert trigger._is_window_invalid(x), x
+
+    trigger._prev_period = 100
+
+    for x in [99, 101]:
+        assert not trigger._is_window_invalid(x), x
+    for x in [0, 80, 120]:
+        assert trigger._is_window_invalid(x), x
+
+    trigger._prev_period = 0
+
+    x = 0
+    assert not trigger._is_window_invalid(x), x
+    for x in [1, 100]:
+        assert trigger._is_window_invalid(x), x
 
 
 # Test the ability to load legacy TriggerConfig

--- a/tests/test_trigger.py
+++ b/tests/test_trigger.py
@@ -108,4 +108,18 @@ def test_trigger_subsampling_edges(cfg: CorrelationTriggerConfig):
     trigger.get_trigger(50000)
 
 
+# Test the ability to load legacy TriggerConfig
+
+def test_load_trigger_config():
+    from ovgenpy.config import yaml
+
+    # Ensure no exceptions
+    yaml.load('''\
+!CorrelationTriggerConfig
+  trigger_strength: 3
+  use_edge_trigger: false
+  responsiveness: 0.2
+  falloff_width: 2
+''')
+
 # TODO test_period get_period()

--- a/tests/test_trigger.py
+++ b/tests/test_trigger.py
@@ -7,7 +7,6 @@ from ovgenpy import triggers
 from ovgenpy.triggers import CorrelationTriggerConfig
 from ovgenpy.wave import Wave
 
-
 triggers.SHOW_TRIGGER = False
 
 
@@ -15,12 +14,14 @@ triggers.SHOW_TRIGGER = False
 def cfg(request):
     use_edge_trigger = request.param
     return CorrelationTriggerConfig(
-        trigger_strength=1,
         use_edge_trigger=use_edge_trigger,
-
         responsiveness=1,
-        falloff_width=2,
     )
+
+
+# I regret adding the nsamp_frame parameter. It makes unit tests hard.
+
+NSAMP_FRAME = round(48000 / 60)
 
 
 def test_trigger(cfg: CorrelationTriggerConfig):
@@ -30,7 +31,7 @@ def test_trigger(cfg: CorrelationTriggerConfig):
     plot = False
     x0 = 24000
     x = x0 - 500
-    trigger = cfg(wave, 4000, subsampling=1)
+    trigger = cfg(wave, 4000, subsampling=1, nsamp_frame=NSAMP_FRAME)
 
     if plot:
         BIG = 0.95
@@ -63,7 +64,7 @@ def test_trigger_subsampling(cfg: CorrelationTriggerConfig):
     iters = 5
     x0 = 24000
     subsampling = 4
-    trigger = cfg(wave, nsamp=100, subsampling=subsampling)
+    trigger = cfg(wave, nsamp=100, subsampling=subsampling, nsamp_frame=NSAMP_FRAME)
     # real nsamp = nsamp*subsampling
     # period = 109
 
@@ -99,7 +100,7 @@ def test_trigger_subsampling_edges(cfg: CorrelationTriggerConfig):
 
     iters = 5
     subsampling = 4
-    trigger = cfg(wave, nsamp=100, subsampling=subsampling)
+    trigger = cfg(wave, nsamp=100, subsampling=subsampling, nsamp_frame=NSAMP_FRAME)
     # real nsamp = nsamp*subsampling
     # period = 109
 

--- a/tests/test_trigger.py
+++ b/tests/test_trigger.py
@@ -21,8 +21,7 @@ def cfg(request):
 
 # I regret adding the nsamp_frame parameter. It makes unit tests hard.
 
-NSAMP_FRAME = round(48000 / 60)
-
+FPS = 60
 
 def test_trigger(cfg: CorrelationTriggerConfig):
     wave = Wave(None, 'tests/impulse24000.wav')
@@ -31,7 +30,7 @@ def test_trigger(cfg: CorrelationTriggerConfig):
     plot = False
     x0 = 24000
     x = x0 - 500
-    trigger = cfg(wave, 4000, subsampling=1, nsamp_frame=NSAMP_FRAME)
+    trigger = cfg(wave, 4000, subsampling=1, fps=FPS)
 
     if plot:
         BIG = 0.95
@@ -64,8 +63,8 @@ def test_trigger_subsampling(cfg: CorrelationTriggerConfig):
     iters = 5
     x0 = 24000
     subsampling = 4
-    trigger = cfg(wave, nsamp=100, subsampling=subsampling, nsamp_frame=NSAMP_FRAME)
-    # real nsamp = nsamp*subsampling
+    trigger = cfg(wave, tsamp=100, subsampling=subsampling, fps=FPS)
+    # real window_samp = window_samp*subsampling
     # period = 109
 
     for i in range(1, iters):
@@ -100,8 +99,8 @@ def test_trigger_subsampling_edges(cfg: CorrelationTriggerConfig):
 
     iters = 5
     subsampling = 4
-    trigger = cfg(wave, nsamp=100, subsampling=subsampling, nsamp_frame=NSAMP_FRAME)
-    # real nsamp = nsamp*subsampling
+    trigger = cfg(wave, tsamp=100, subsampling=subsampling, fps=FPS)
+    # real window_samp = window_samp*subsampling
     # period = 109
 
     trigger.get_trigger(0)

--- a/tests/test_windows.py
+++ b/tests/test_windows.py
@@ -1,0 +1,49 @@
+import pytest
+import numpy as np
+from numpy.testing import assert_equal
+
+from ovgenpy.utils.windows import leftpad, midpad
+
+
+def test_leftpad():
+    before = 10
+    data = np.linspace(before - 1, 0, before)
+
+    after = 3
+    assert_equal(leftpad(data, after), data[-after:])
+
+    after = 10
+    assert_equal(leftpad(data, after), data)
+
+    after = 25
+    lp = leftpad(data, after)
+    assert_equal(lp[-before:], data)
+    assert_equal(lp[:-before], 0)
+
+
+@pytest.mark.parametrize('before', [10, 11])
+def test_midpad(before):
+    # Midpad should work for both odd and even arrays.
+    data = np.arange(before)
+
+    # Test shrinking.
+    after = before - 6
+    half = (before - after) // 2
+    assert_equal(midpad(data, after), data[half:-half])
+
+    # Test identity.
+    after = before
+    assert_equal(midpad(data, after), data)
+
+    # Test expanding.
+    after = before + 12
+    half = (after - before) // 2
+    lp = midpad(data, after)
+
+    assert_equal(lp[:half], 0)
+    assert_equal(lp[half:-half], data)
+    assert_equal(lp[-half:], 0)
+
+    # I don't test odd values, except to ensure sizes are correct.
+    for after in [before - 5, before + 15]:
+        assert len(midpad(data, after)) == after


### PR DESCRIPTION
- (Mostly) fix lag when using long input windows
    - Prevent CorrelationTrigger from looking backwards >= 1 frame in time)
    - (Don't want to implement) configurable left-taper steepness, up to half frame?
    - Maybe removing 2-frame repetition is a mistake when dealing with <60Hz waves
- Add `trigger_diameter` field (* window size = movement distance)
- Add `trigger_falloff[0,1]` fields (* audio period = correlation diameter and taper)
- Rename fields and convert old names into aliases
- Move trigger defaults from `default_config()` to `CorrelationTriggerConfig`

Fixes #17.

Potential issues:
- Does it hurt treble quality?
- Performance impact?
    - Don't calculate pitch twice.
- [x] Reexamine 01469c1de1340a7293eed679ea1d8d5370cabbeb
    - it's not a Gaussian anymore, it's a `min(half-Hann with configurable right end, pitch-dependent envelope)`.
- [x] Drastically hurts quality of Time Trax bell bass (https://www.youtube.com/watch?v=DcwqdeJ7DSk)
    - PR fixes lag but reduces usable data width. Fixed with extra trigger_width.
- [x] Performance: Benchmarking and profiling
------
sd3-winter trigger benchmark
- Before: 388fps
- After: 196fps

- [x] Calculate pitch once, pass into _update_buffer
    - 289fps
- [x] Don't regenerate window unless period changes by at least 1 semitone
    - ~~361fps~~ BUG: no data windowing whatsoever
    - 332fps