### PR TITLE
Fix bugs when dumping/loading YAML in another directory

### DIFF
--- a/ovgenpy/channel.py
+++ b/ovgenpy/channel.py
@@ -1,3 +1,4 @@
+from os.path import abspath
 from typing import TYPE_CHECKING, Any
 
 from ovgenpy.config import register_config, Alias
@@ -42,7 +43,7 @@ class Channel:
 
         # Create a Wave object.
         wcfg = _WaveConfig(amplification=ovgen_cfg.amplification * cfg.ampl_ratio)
-        self.wave = Wave(wcfg, cfg.wav_path)
+        self.wave = Wave(wcfg, abspath(cfg.wav_path))
 
         # Compute subsampling (array stride).
         tw = coalesce(cfg.trigger_width, ovgen_cfg.trigger_width)

--- a/ovgenpy/cli.py
+++ b/ovgenpy/cli.py
@@ -86,6 +86,7 @@ def main(
 
     # Create cfg: Config object.
     cfg: Config = None
+    cfg_dir: str = None
 
     wav_list: List[Path] = []
     for name in files:
@@ -106,6 +107,7 @@ def main(
                 raise click.ClickException(
                     f'When supplying config {path}, you cannot supply other files/folders')
             cfg = yaml.load(path)
+            cfg_dir = path.parent
             break
 
         else:
@@ -136,6 +138,7 @@ def main(
             # amplification...render=default,
             outputs=outputs
         )
+        cfg_dir = '.'
 
     if show_gui:
         raise OvgenError('GUI not implemented')
@@ -171,4 +174,4 @@ def main(
                 cProfile.runctx('Ovgen(cfg).play()', globals(), locals(), path)
 
             else:
-                Ovgen(cfg).play()
+                Ovgen(cfg, cfg_dir).play()

--- a/ovgenpy/cli.py
+++ b/ovgenpy/cli.py
@@ -47,7 +47,7 @@ PROFILE_DUMP_NAME = 'cprofile'
         'Config: Output video path')
 # Disables GUI
 @click.option('--write', '-w', is_flag=True, help=
-        "Write config YAML file to path (don't open GUI).")
+        "Write config YAML file to current directory (don't open GUI).")
 @click.option('--play', '-p', is_flag=True, help=
         "Preview or render (don't open GUI).")
 # Debugging
@@ -144,11 +144,13 @@ def main(
             raise click.ClickException('Must specify files or folders to play')
         if write:
             if audio:
-                write_path = Path(audio).with_suffix(YAML_NAME)
+                # Write file to current working dir, not audio dir.
+                audio_name = Path(audio).name
+                # Add .yaml extension
+                write_path = Path(audio_name).with_suffix(YAML_NAME)
             else:
                 write_path = DEFAULT_CONFIG_PATH
 
-            # TODO test writing YAML file
             yaml.dump(cfg, write_path)
 
         if play:

--- a/ovgenpy/outputs.py
+++ b/ovgenpy/outputs.py
@@ -3,7 +3,7 @@ import shlex
 import subprocess
 from abc import ABC, abstractmethod
 from os.path import abspath
-from typing import TYPE_CHECKING, Type, List, Union
+from typing import TYPE_CHECKING, Type, List, Union, Optional
 
 from ovgenpy.config import register_config
 
@@ -124,7 +124,8 @@ class PipeOutput(Output):
 
 @register_config
 class FFmpegOutputConfig(IOutputConfig):
-    path: str
+    # path=None writes to stdout.
+    path: Optional[str]
     args: str = ''
 
     # Do not use `-movflags faststart`, I get corrupted mp4 files (missing MOOV)
@@ -142,7 +143,13 @@ class FFmpegOutput(PipeOutput):
         ffmpeg = _FFmpegCommand([FFMPEG, '-y'], ovgen_cfg)
         ffmpeg.add_output(cfg)
         ffmpeg.templates.append(cfg.args)
-        self.open(ffmpeg.popen([abspath(cfg.path)], self.bufsize))
+
+        if cfg.path is None:
+            video_path = '-'    # Write to stdout
+        else:
+            video_path = abspath(cfg.path)
+
+        self.open(ffmpeg.popen([video_path], self.bufsize))
 
 
 # FFplayOutput

--- a/ovgenpy/outputs.py
+++ b/ovgenpy/outputs.py
@@ -2,6 +2,7 @@
 import shlex
 import subprocess
 from abc import ABC, abstractmethod
+from os.path import abspath
 from typing import TYPE_CHECKING, Type, List, Union
 
 from ovgenpy.config import register_config
@@ -55,7 +56,7 @@ class _FFmpegCommand:
 
         self.templates += ffmpeg_input_video(ovgen_cfg)  # video
         if ovgen_cfg.master_audio:
-            audio_path = shlex.quote(ovgen_cfg.master_audio)
+            audio_path = shlex.quote(abspath(ovgen_cfg.master_audio))
             self.templates.append(f'-ss {ovgen_cfg.begin_time}')
             self.templates += ffmpeg_input_audio(audio_path)    # audio
 
@@ -141,7 +142,7 @@ class FFmpegOutput(PipeOutput):
         ffmpeg = _FFmpegCommand([FFMPEG, '-y'], ovgen_cfg)
         ffmpeg.add_output(cfg)
         ffmpeg.templates.append(cfg.args)
-        self.open(ffmpeg.popen([cfg.path], self.bufsize))
+        self.open(ffmpeg.popen([abspath(cfg.path)], self.bufsize))
 
 
 # FFplayOutput

--- a/ovgenpy/util.py
+++ b/ovgenpy/util.py
@@ -1,6 +1,8 @@
-from functools import wraps
+import os
+from contextlib import contextmanager
 from itertools import chain
-from typing import Callable, Tuple, TypeVar, Iterator
+from pathlib import Path
+from typing import Callable, Tuple, TypeVar, Iterator, Union
 
 import numpy as np
 
@@ -80,20 +82,12 @@ def find(a: 'np.ndarray[T]', predicate: 'Callable[[np.ndarray[T]], np.ndarray[bo
         i0 = i1
 
 
-# # Adapted from https://stackoverflow.com/a/9458386
-# def curry(x, argc=None):
-#     if argc is None:
-#         argc = x.__code__.co_argcount
-#
-#     @wraps(x)
-#     def p(*a):
-#         if len(a) == argc:
-#             return x(*a)
-#
-#         def q(*b):
-#             return x(*(a + b))
-#
-#         return curry(q, argc - len(a))
-#
-#     del p.__wrapped__
-#     return p
+@contextmanager
+def pushd(new_dir: Union[Path, str]):
+    previous_dir = os.getcwd()
+    os.chdir(str(new_dir))
+    try:
+        yield
+    finally:
+        os.chdir(previous_dir)
+

--- a/ovgenpy/util.py
+++ b/ovgenpy/util.py
@@ -80,19 +80,20 @@ def find(a: 'np.ndarray[T]', predicate: 'Callable[[np.ndarray[T]], np.ndarray[bo
         i0 = i1
 
 
-# Adapted from https://stackoverflow.com/a/9458386
-def curry(x, argc=None):
-    if argc is None:
-        argc = x.__code__.co_argcount
-
-    @wraps(x)
-    def p(*a):
-        if len(a) == argc:
-            return x(*a)
-
-        def q(*b):
-            return x(*(a + b))
-
-        return curry(q, argc - len(a))
-
-    return p
+# # Adapted from https://stackoverflow.com/a/9458386
+# def curry(x, argc=None):
+#     if argc is None:
+#         argc = x.__code__.co_argcount
+#
+#     @wraps(x)
+#     def p(*a):
+#         if len(a) == argc:
+#             return x(*a)
+#
+#         def q(*b):
+#             return x(*(a + b))
+#
+#         return curry(q, argc - len(a))
+#
+#     del p.__wrapped__
+#     return p

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,20 @@
+import os
+import subprocess
+from typing import TYPE_CHECKING
+
+import pytest
+
+if TYPE_CHECKING:
+    import pytest_mock
+
+
+@pytest.fixture
+def Popen(mocker: 'pytest_mock.MockFixture'):
+    Popen = mocker.patch.object(subprocess, 'Popen', autospec=True)
+    popen = Popen.return_value
+
+    popen.stdin = open(os.devnull, "wb")
+    popen.stdout = open(os.devnull, "rb")
+    popen.wait.return_value = 0
+
+    yield Popen

--- a/tests/test_channel.py
+++ b/tests/test_channel.py
@@ -64,7 +64,7 @@ def test_channel_subsampling(
     assert trigger._subsampling == channel.trigger_subsampling
 
     # Ensure ovgenpy calls render using channel.window_samp and render_subsampling.
-    ovgen = Ovgen(cfg)
+    ovgen = Ovgen(cfg, '.')
     renderer = mocker.patch.object(Ovgen, '_load_renderer').return_value
     ovgen.play()
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -7,6 +7,7 @@ import pytest
 from click.testing import CliRunner
 
 from ovgenpy import cli
+from ovgenpy.cli import YAML_NAME
 from ovgenpy.config import yaml
 from ovgenpy.ovgenpy import Config
 
@@ -83,14 +84,19 @@ def test_file_dirs(any_sink, wav_dir):
 
 
 def test_write_dir(yaml_sink):
-    """ Loading `--audio another/dir` should write YAML to current dir. """
+    """ Loading `--audio another/dir` should write YAML to current dir.
+    Writing YAML to audio dir: causes relative paths (relative to pwd) to break. """
 
     audio_path = Path('tests/sine440.wav')
-    arg_str = f'tests -a {audio_path} -w'
+    arg_str = f'tests -a {audio_path}'
 
-    cfg, outpath = yaml_sink(arg_str)
+    cfg, outpath = yaml_sink(arg_str)   # type: Config, Path
     assert isinstance(outpath, Path)
 
-    assert outpath.parent == '.'
-    assert outpath.name == outpath
-    assert outpath == audio_path.with_suffix(YAML_NAME).name
+    # Ensure YAML config written to current dir.
+    assert outpath.parent == Path()
+    assert outpath.name == str(outpath)
+    assert str(outpath) == audio_path.with_suffix(YAML_NAME).name
+
+    # Ensure config paths are valid.
+    assert outpath.parent / cfg.master_audio == audio_path

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -80,3 +80,17 @@ def test_file_dirs(any_sink, wav_dir):
     assert isinstance(cfg, Config)
 
     assert [chan.wav_path for chan in cfg.channels] == wavs
+
+
+def test_write_dir(yaml_sink):
+    """ Loading `--audio another/dir` should write YAML to current dir. """
+
+    audio_path = Path('tests/sine440.wav')
+    arg_str = f'tests -a {audio_path} -w'
+
+    cfg, outpath = yaml_sink(arg_str)
+    assert isinstance(outpath, Path)
+
+    assert outpath.parent == '.'
+    assert outpath.name == outpath
+    assert outpath == audio_path.with_suffix(YAML_NAME).name

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -67,7 +67,7 @@ def test_ovgen_terminate_ffplay(Popen, mocker: 'pytest_mock.MockFixture'):
         master_audio='tests/sine440.wav',
         outputs=[FFplayOutputConfig()]
     )
-    ovgen = Ovgen(cfg)
+    ovgen = Ovgen(cfg, '.')
 
     render_frame = mocker.patch.object(MatplotlibRenderer, 'render_frame')
     render_frame.side_effect = DummyException()

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 import pytest
@@ -13,14 +14,13 @@ if TYPE_CHECKING:
     import pytest_mock
 
 CFG = default_config(render=RendererConfig(WIDTH, HEIGHT))
-STDOUT_CFG = FFmpegOutputConfig('-', '-f nut')
+NULL_CFG = FFmpegOutputConfig(None, '-f null')
 
 
 def test_render_output():
     """ Ensure rendering to output does not raise exceptions. """
     renderer = MatplotlibRenderer(CFG.render, CFG.layout, nplots=1)
-    output_cfg = FFmpegOutputConfig('-', '-f nut')
-    out = FFmpegOutput(CFG, output_cfg)
+    out: FFmpegOutput = NULL_CFG(CFG)
 
     renderer.render_frame([ALL_ZEROS])
     out.write_frame(renderer.get_frame())
@@ -29,12 +29,14 @@ def test_render_output():
 
 
 def test_output():
-    out = FFmpegOutput(CFG, STDOUT_CFG)
+    out: FFmpegOutput = NULL_CFG(CFG)
 
     frame = bytes(WIDTH * HEIGHT * RGB_DEPTH)
     out.write_frame(frame)
 
     assert out.close() == 0
+    # Ensure video is written to stdout, and not current directory.
+    assert not Path('-').exists()
 
 
 # Ensure ovgen terminates FFplay upon exceptions.

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -1,5 +1,3 @@
-import os
-import subprocess
 from typing import TYPE_CHECKING
 
 import pytest
@@ -42,6 +40,7 @@ def test_output():
 # Ensure ovgen terminates FFplay upon exceptions.
 
 
+@pytest.mark.usefixtures('Popen')
 def test_terminate_ffplay(Popen):
     """ FFplayOutput unit test: Ensure ffmpeg and ffplay are terminated when Python
     exceptions occur.
@@ -58,6 +57,7 @@ def test_terminate_ffplay(Popen):
             popen.terminate.assert_called()
 
 
+@pytest.mark.usefixtures('Popen')
 def test_ovgen_terminate_ffplay(Popen, mocker: 'pytest_mock.MockFixture'):
     """ Integration test: Ensure ffmpeg and ffplay are terminated when Python exceptions
     occur. """
@@ -84,17 +84,6 @@ def test_ovgen_terminate_ffplay(Popen, mocker: 'pytest_mock.MockFixture'):
 # TODO integration test without audio
 
 # TODO integration test on ???
-
-
-@pytest.fixture
-def Popen(mocker: 'pytest_mock.MockFixture'):
-    Popen = mocker.patch.object(subprocess, 'Popen', autospec=True).return_value
-
-    Popen.stdin = open(os.devnull, "wb")
-    Popen.stdout = open(os.devnull, "rb")
-    Popen.wait.return_value = 0
-
-    yield Popen
 
 
 class DummyException(Exception):


### PR DESCRIPTION
- `-w ../song.wav` should write to `song.yaml`
- `ovgenpy ../song.yaml` which contains `song.wav` should look in `..` and not `.`

Fixes #47.