### PR TITLE
 Properly terminate FFmpeg output processes

### DIFF
--- a/ovgenpy/outputs.py
+++ b/ovgenpy/outputs.py
@@ -145,8 +145,7 @@ class FFmpegOutputConfig(IOutputConfig):
     path: Optional[str]
     args: str = ''
 
-    # Do not use `-movflags faststart`, I get corrupted mp4 files (missing MOOV)
-    video_template: str = '-c:v libx264 -crf 18 -preset superfast'
+    video_template: str = '-c:v libx264 -crf 18 -preset superfast -movflags faststart'
     audio_template: str = '-c:a aac -b:a 384k'
 
 

--- a/ovgenpy/outputs.py
+++ b/ovgenpy/outputs.py
@@ -49,7 +49,7 @@ def register_output(config_t: Type[IOutputConfig]):
 
 # FFmpeg command line generation
 
-class _FFmpegCommand:
+class _FFmpegProcess:
     def __init__(self, templates: List[str], ovgen_cfg: 'Config'):
         self.templates = templates
         self.ovgen_cfg = ovgen_cfg
@@ -147,7 +147,7 @@ class FFmpegOutput(PipeOutput):
     def __init__(self, ovgen_cfg: 'Config', cfg: FFmpegOutputConfig):
         super().__init__(ovgen_cfg, cfg)
 
-        ffmpeg = _FFmpegCommand([FFMPEG, '-y'], ovgen_cfg)
+        ffmpeg = _FFmpegProcess([FFMPEG, '-y'], ovgen_cfg)
         ffmpeg.add_output(cfg)
         ffmpeg.templates.append(cfg.args)
 
@@ -174,7 +174,7 @@ class FFplayOutput(PipeOutput):
     def __init__(self, ovgen_cfg: 'Config', cfg: FFplayOutputConfig):
         super().__init__(ovgen_cfg, cfg)
 
-        ffmpeg = _FFmpegCommand([FFMPEG], ovgen_cfg)
+        ffmpeg = _FFmpegProcess([FFMPEG], ovgen_cfg)
         ffmpeg.add_output(cfg)
         ffmpeg.templates.append('-f nut')
 

--- a/ovgenpy/ovgenpy.py
+++ b/ovgenpy/ovgenpy.py
@@ -232,8 +232,13 @@ class Ovgen:
                         for output in self.outputs:
                             output.write_frame(frame)
 
+            if self.raise_on_teardown:
+                raise self.raise_on_teardown
+
         if PRINT_TIMESTAMP:
             # noinspection PyUnboundLocalVariable
             dtime = time.perf_counter() - begin
             render_fps = (end_frame - begin_frame) / dtime
             print(f'FPS = {render_fps}')
+
+    raise_on_teardown: Exception = None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,11 +10,15 @@ if TYPE_CHECKING:
 
 @pytest.fixture
 def Popen(mocker: 'pytest_mock.MockFixture'):
+    real_Popen = subprocess.Popen
+
+    def popen_factory(*args, **kwargs):
+        popen = mocker.create_autospec(real_Popen)
+        popen.stdin = open(os.devnull, "wb")
+        popen.stdout = open(os.devnull, "rb")
+        popen.wait.return_value = 0
+        return popen
+
     Popen = mocker.patch.object(subprocess, 'Popen', autospec=True)
-    popen = Popen.return_value
-
-    popen.stdin = open(os.devnull, "wb")
-    popen.stdout = open(os.devnull, "rb")
-    popen.wait.return_value = 0
-
+    Popen.side_effect = popen_factory
     yield Popen

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,8 +14,11 @@ def Popen(mocker: 'pytest_mock.MockFixture'):
 
     def popen_factory(*args, **kwargs):
         popen = mocker.create_autospec(real_Popen)
-        popen.stdin = open(os.devnull, "wb")
-        popen.stdout = open(os.devnull, "rb")
+
+        popen.stdin = mocker.mock_open()(os.devnull, "wb")
+        popen.stdout = mocker.mock_open()(os.devnull, "rb")
+        assert popen.stdin != popen.stdout
+
         popen.wait.return_value = 0
         return popen
 

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -83,6 +83,7 @@ def test_ovgen_terminate_ffplay(Popen, mocker: 'pytest_mock.MockFixture'):
         popen.terminate.assert_called()
 
 
+@pytest.mark.skip('Launches ffmpeg and ffplay processes, creating a ffplay window')
 def test_ovgen_terminate_works():
     """ Ensure that ffmpeg/ffplay terminate quickly after Python exceptions, when
     `popen.terminate()` is called. """

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -39,9 +39,24 @@ def test_output():
     assert not Path('-').exists()
 
 
+# Ensure ovgen closes pipe to output upon completion.
+@pytest.mark.usefixtures('Popen')
+def test_close_output(Popen):
+    """ FFplayOutput unit test: Ensure ffmpeg and ffplay are terminated when Python
+    exceptions occur.
+    """
+
+    ffplay_cfg = FFplayOutputConfig()
+    output: FFplayOutput
+    with ffplay_cfg(CFG) as output:
+        pass
+
+    output._pipeline[0].stdin.close.assert_called()
+    for popen in output._pipeline:
+        popen.wait.assert_called()  # Does wait() need to be called?
+
+
 # Ensure ovgen terminates FFplay upon exceptions.
-
-
 @pytest.mark.usefixtures('Popen')
 def test_terminate_ffplay(Popen):
     """ FFplayOutput unit test: Ensure ffmpeg and ffplay are terminated when Python


### PR DESCRIPTION
- Close output stdin when closing outputs.
- Call `popen.wait(1 second)` otherwise `popen.kill()` to ensure all output processes terminate.
- Call FFmpegOutput with `-movflags faststart`.
    - Closing ffmpeg stdin properly causes `-movflags faststart` to no longer produces corrupted video files.