### PR TITLE
Demean trigger data, add LocalPostTrigger, change defaults

### DIFF
--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -2,6 +2,15 @@
   <profile version="1.0">
     <option name="myName" value="Project Default" />
     <inspection_tool class="InconsistentLineSeparators" enabled="true" level="WARNING" enabled_by_default="true" />
+    <inspection_tool class="PyPackageRequirementsInspection" enabled="true" level="WARNING" enabled_by_default="true">
+      <option name="ignoredPackages">
+        <value>
+          <list size="1">
+            <item index="0" class="java.lang.String" itemvalue="PyQt5" />
+          </list>
+        </value>
+      </option>
+    </inspection_tool>
     <inspection_tool class="PyPep8Inspection" enabled="true" level="WEAK WARNING" enabled_by_default="true">
       <option name="ignoredErrors">
         <list>

--- a/.idea/ovgenpy.iml
+++ b/.idea/ovgenpy.iml
@@ -2,6 +2,7 @@
 <module type="PYTHON_MODULE" version="4">
   <component name="NewModuleRootManager">
     <content url="file://$MODULE_DIR$">
+      <excludeFolder url="file://$MODULE_DIR$/.hypothesis" />
       <excludeFolder url="file://$MODULE_DIR$/.ipynb_checkpoints" />
       <excludeFolder url="file://$MODULE_DIR$/.pytest_cache" />
       <excludeFolder url="file://$MODULE_DIR$/ovgenpy.egg-info" />
@@ -13,7 +14,7 @@
     <option name="requirementsPath" value="" />
   </component>
   <component name="TestRunnerService">
-    <option name="projectConfiguration" value="py.test" />
+    <option name="projectConfiguration" value="pytest" />
     <option name="PROJECT_TEST_RUNNER" value="py.test" />
   </component>
 </module>

--- a/ovgenpy/cli.py
+++ b/ovgenpy/cli.py
@@ -96,7 +96,7 @@ def main(
             if len(files) > 1:
                 # Warning is technically optional, since wav_prefix has been removed.
                 raise click.ClickException(
-                    f'When supplying folder {path}, you cannot supply other files/folders')
+                    f'Cannot supply multiple arguments when providing folder {path}')
             matches = sorted(path.glob('*.wav'))
             wav_list += matches
             break
@@ -105,7 +105,7 @@ def main(
             # Load a YAML file to cfg, and skip default_config().
             if len(files) > 1:
                 raise click.ClickException(
-                    f'When supplying config {path}, you cannot supply other files/folders')
+                    f'Cannot supply multiple arguments when providing config {path}')
             cfg = yaml.load(path)
             cfg_dir = path.parent
             break

--- a/ovgenpy/config.py
+++ b/ovgenpy/config.py
@@ -152,7 +152,8 @@ class _EnumMixin:
 
 # Miscellaneous
 
-class OvgenError(Exception):
+class OvgenError(ValueError):
+    """ Error caused by invalid end-user input (via CLI or YAML config). """
     pass
 
 

--- a/ovgenpy/ovgenpy.py
+++ b/ovgenpy/ovgenpy.py
@@ -9,7 +9,8 @@ from ovgenpy import outputs
 from ovgenpy.channel import Channel, ChannelConfig
 from ovgenpy.config import register_config, register_enum, Ignored
 from ovgenpy.renderer import MatplotlibRenderer, RendererConfig, LayoutConfig
-from ovgenpy.triggers import ITriggerConfig, CorrelationTriggerConfig, PerFrameCache
+from ovgenpy.triggers import ITriggerConfig, CorrelationTriggerConfig, PerFrameCache, \
+    LocalPostTriggerConfig
 from ovgenpy.util import pushd, coalesce
 from ovgenpy.utils import keyword_dataclasses as dc
 from ovgenpy.utils.keyword_dataclasses import field
@@ -83,7 +84,12 @@ def default_config(**kwargs):
         fps=_FPS,
 
         width_ms=25,
-        trigger=CorrelationTriggerConfig(),
+        trigger=CorrelationTriggerConfig(
+            edge_strength=0,
+            responsiveness=0.5,
+            use_edge_trigger=False,
+            post=LocalPostTriggerConfig(strength=1),
+        ),
         channels=[],
 
         amplification=1,

--- a/ovgenpy/ovgenpy.py
+++ b/ovgenpy/ovgenpy.py
@@ -88,7 +88,8 @@ def default_config(**kwargs):
             edge_strength=0,
             responsiveness=0.5,
             use_edge_trigger=False,
-            post=LocalPostTriggerConfig(strength=0.1),
+            # Removed due to speed hit.
+            # post=LocalPostTriggerConfig(strength=0.1),
         ),
         channels=[],
 

--- a/ovgenpy/ovgenpy.py
+++ b/ovgenpy/ovgenpy.py
@@ -39,17 +39,18 @@ class Config:
     begin_time: float = 0
     end_time: float = None
 
-    subsampling: int = 1
-
     width_ms: int
+    subsampling: int = 1
     trigger_width: int = 1
     render_width: int = 1
+
+    amplification: float
+
     trigger: ITriggerConfig  # Can be overriden per Wave
 
     # Can override trigger_width, render_width, trigger
     channels: List[ChannelConfig] = field(default_factory=list)
 
-    amplification: float
     layout: LayoutConfig
     render: RendererConfig
 
@@ -82,10 +83,12 @@ def default_config(**kwargs):
     cfg = Config(
         master_audio='',
         fps=_FPS,
+        amplification=1,
 
-        width_ms=25,
+        width_ms=40,
+        subsampling=2,
         trigger=CorrelationTriggerConfig(
-            edge_strength=0,
+            edge_strength=2,
             responsiveness=0.5,
             use_edge_trigger=False,
             # Removed due to speed hit.
@@ -93,9 +96,8 @@ def default_config(**kwargs):
         ),
         channels=[],
 
-        amplification=1,
-        layout=LayoutConfig(ncols=1),
-        render=RendererConfig(1280, 720),
+        layout=LayoutConfig(ncols=2),
+        render=RendererConfig(800, 480),
 
         outputs=[
             outputs.FFplayOutputConfig(),

--- a/ovgenpy/ovgenpy.py
+++ b/ovgenpy/ovgenpy.py
@@ -88,7 +88,7 @@ def default_config(**kwargs):
             edge_strength=0,
             responsiveness=0.5,
             use_edge_trigger=False,
-            post=LocalPostTriggerConfig(strength=1),
+            post=LocalPostTriggerConfig(strength=1),    # FIXME
         ),
         channels=[],
 

--- a/ovgenpy/ovgenpy.py
+++ b/ovgenpy/ovgenpy.py
@@ -9,7 +9,7 @@ from ovgenpy import outputs
 from ovgenpy.channel import Channel, ChannelConfig
 from ovgenpy.config import register_config, register_enum, Ignored
 from ovgenpy.renderer import MatplotlibRenderer, RendererConfig, LayoutConfig
-from ovgenpy.triggers import ITriggerConfig, CorrelationTriggerConfig, Trigger
+from ovgenpy.triggers import ITriggerConfig, CorrelationTriggerConfig, PerFrameCache
 from ovgenpy.util import pushd, coalesce
 from ovgenpy.utils import keyword_dataclasses as dc
 from ovgenpy.utils.keyword_dataclasses import field
@@ -203,7 +203,8 @@ class Ovgen:
                     sample = round(wave.smp_s * time_seconds)
 
                     if not_benchmarking or benchmark_mode == BenchmarkMode.TRIGGER:
-                        trigger_sample = channel.trigger.get_trigger(sample)
+                        cache = PerFrameCache()
+                        trigger_sample = channel.trigger.get_trigger(sample, cache)
                     else:
                         trigger_sample = sample
 

--- a/ovgenpy/ovgenpy.py
+++ b/ovgenpy/ovgenpy.py
@@ -88,7 +88,7 @@ def default_config(**kwargs):
             edge_strength=0,
             responsiveness=0.5,
             use_edge_trigger=False,
-            post=LocalPostTriggerConfig(strength=1),    # FIXME
+            post=LocalPostTriggerConfig(strength=0.1),
         ),
         channels=[],
 

--- a/ovgenpy/renderer.py
+++ b/ovgenpy/renderer.py
@@ -182,9 +182,9 @@ class MatplotlibRenderer:
 
 @register_config(always_dump='orientation')
 class LayoutConfig:
+    orientation: str = 'h'
     nrows: Optional[int] = None
     ncols: Optional[int] = None
-    orientation: str = 'h'
 
     def __post_init__(self):
         if not self.nrows:

--- a/ovgenpy/triggers.py
+++ b/ovgenpy/triggers.py
@@ -456,6 +456,16 @@ class LocalPostTrigger(PostTrigger):
         assert len(corr) == 2*N - 1
         mid = N-1
 
+        # If we're near a falling edge, don't try to make drastic changes.
+        if corr[mid] < 0:
+            # Give up early.
+            return index
+
+        # Don't punish negative results too much.
+        # (probably useless. if corr[mid] >= 0,
+        # all other negative entries will never be optimal.)
+        # np.abs(corr, out=corr)
+
         # Subtract cost function
         cost = self._cost_norm / cache.period
         corr -= cost

--- a/ovgenpy/triggers.py
+++ b/ovgenpy/triggers.py
@@ -195,7 +195,8 @@ class CorrelationTrigger(Trigger):
         use_edge_trigger = self.cfg.use_edge_trigger
 
         # Get data
-        data = self._wave.get_around(index, N, self._subsampling)
+        subsampling = self._subsampling
+        data = self._wave.get_around(index, N, subsampling)
 
         # Window data
         period = get_period(data)
@@ -231,7 +232,7 @@ class CorrelationTrigger(Trigger):
         corr = signal.correlate(data, prev_buffer)
         assert len(corr) == 2*N - 1
 
-        # Find optimal offset (within ±N//4)
+        # Find optimal offset (within trigger_diameter, default=±N/4)
         mid = N-1
         radius = round(N * self.cfg.trigger_diameter / 2)
 
@@ -244,10 +245,10 @@ class CorrelationTrigger(Trigger):
         # argmax(corr) == mid + peak_offset == (data >> peak_offset)
         # peak_offset == argmax(corr) - mid
         peak_offset = np.argmax(corr) - mid   # type: int
-        trigger = index + (self._subsampling * peak_offset)
+        trigger = index + (subsampling * peak_offset)
 
         # Update correlation buffer (distinct from visible area)
-        aligned = self._wave.get_around(trigger, self._buffer_nsamp, self._subsampling)
+        aligned = self._wave.get_around(trigger, self._buffer_nsamp, subsampling)
         self._update_buffer(aligned, period)
 
         if use_edge_trigger:

--- a/ovgenpy/util.py
+++ b/ovgenpy/util.py
@@ -20,6 +20,10 @@ def coalesce(*args):
     return args[-1]
 
 
+def obj_name(obj) -> str:
+    return type(obj).__name__
+
+
 T = TypeVar('T')
 
 # Adapted from https://github.com/numpy/numpy/issues/2269#issuecomment-14436725

--- a/ovgenpy/wave.py
+++ b/ovgenpy/wave.py
@@ -95,7 +95,7 @@ class Wave:
         return out
 
     def get_around(self, sample: int, region_nsamp: int, subsampling: int):
-        """" Copies self.data[...] """
+        """ Copies self.data[...] """
         region_nsamp *= subsampling
         end = sample + region_nsamp // 2
         begin = end - region_nsamp

--- a/tests/test_trigger.py
+++ b/tests/test_trigger.py
@@ -4,7 +4,7 @@ from matplotlib.axes import Axes
 from matplotlib.figure import Figure
 
 from ovgenpy import triggers
-from ovgenpy.triggers import CorrelationTriggerConfig, CorrelationTrigger
+from ovgenpy.triggers import CorrelationTriggerConfig, CorrelationTrigger, PerFrameCache
 from ovgenpy.wave import Wave
 
 triggers.SHOW_TRIGGER = False
@@ -30,7 +30,7 @@ def test_trigger(cfg: CorrelationTriggerConfig):
     plot = False
     x0 = 24000
     x = x0 - 500
-    trigger = cfg(wave, 4000, subsampling=1, fps=FPS)
+    trigger: CorrelationTrigger = cfg(wave, 4000, subsampling=1, fps=FPS)
 
     if plot:
         BIG = 0.95
@@ -45,7 +45,7 @@ def test_trigger(cfg: CorrelationTriggerConfig):
 
     for i, ax in enumerate(axes):
         if i:
-            offset = trigger.get_trigger(x)
+            offset = trigger.get_trigger(x, PerFrameCache())
             print(offset)
             assert offset == x0
         if plot:
@@ -67,8 +67,10 @@ def test_trigger_subsampling(cfg: CorrelationTriggerConfig):
     # real window_samp = window_samp*subsampling
     # period = 109
 
+    cache = PerFrameCache()
+
     for i in range(1, iters):
-        offset = trigger.get_trigger(x0)
+        offset = trigger.get_trigger(x0, cache)
         print(offset)
 
         # Debugging CorrelationTrigger.get_trigger:
@@ -103,9 +105,9 @@ def test_trigger_subsampling_edges(cfg: CorrelationTriggerConfig):
     # real window_samp = window_samp*subsampling
     # period = 109
 
-    trigger.get_trigger(0)
-    trigger.get_trigger(-1000)
-    trigger.get_trigger(50000)
+    trigger.get_trigger(0, PerFrameCache())
+    trigger.get_trigger(-1000, PerFrameCache())
+    trigger.get_trigger(50000, PerFrameCache())
 
 
 def test_trigger_should_recalc_window():

--- a/tests/test_trigger.py
+++ b/tests/test_trigger.py
@@ -5,7 +5,7 @@ from matplotlib.figure import Figure
 
 from ovgenpy import triggers
 from ovgenpy.triggers import CorrelationTriggerConfig, CorrelationTrigger, \
-    PerFrameCache, ZeroCrossingTriggerConfig
+    PerFrameCache, ZeroCrossingTriggerConfig, LocalPostTriggerConfig
 from ovgenpy.wave import Wave
 
 triggers.SHOW_TRIGGER = False
@@ -20,7 +20,11 @@ def cfg(request):
     )
 
 
-@pytest.fixture(scope='session', params=[None, ZeroCrossingTriggerConfig()])
+@pytest.fixture(scope='session', params=[
+    None,
+    ZeroCrossingTriggerConfig(),
+    LocalPostTriggerConfig(strength=1)
+])
 def post_cfg(request):
     post = request.param
     return CorrelationTriggerConfig(


### PR DESCRIPTION
- Add per-frame cache shared across triggers
- Add LocalPostTrigger
- Move ZeroCrossingTrigger from use_edge_trigger to post
- CT and LPT demean trigger data
- Change default settings and format

doesn't seem to hurt performance much, until you enable LocalPostTrigger

TODO rename tsamp to buffer_nsamp
TODO rename to post_trigger 

partially implements #8 and #54 