### PR TITLE
Add Config.render_subfps parameter to reduce CPU usage

### DIFF
--- a/ovgenpy/outputs.py
+++ b/ovgenpy/outputs.py
@@ -34,10 +34,15 @@ class Output(ABC):
         frame_bytes = rcfg.height * rcfg.width * RGB_DEPTH
         self.bufsize = frame_bytes * FRAMES_TO_BUFFER
 
+    def __enter__(self):
+        return self
+
     @abstractmethod
     def write_frame(self, frame: bytes) -> None:
         """ Output a Numpy ndarray. """
 
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        pass
 
 # Glue logic
 

--- a/ovgenpy/outputs.py
+++ b/ovgenpy/outputs.py
@@ -85,7 +85,7 @@ class _FFmpegProcess:
 
 
 def ffmpeg_input_video(cfg: 'Config') -> List[str]:
-    fps = cfg.fps
+    fps = cfg.render_fps
     width = cfg.render.width
     height = cfg.render.height
 

--- a/ovgenpy/ovgenpy.py
+++ b/ovgenpy/ovgenpy.py
@@ -96,7 +96,7 @@ class Config:
 
 _FPS = 60  # f_s
 
-def default_config(**kwargs):
+def default_config(**kwargs) -> Config:
     cfg = Config(
         render_subfps=2,
         master_audio='',

--- a/ovgenpy/ovgenpy.py
+++ b/ovgenpy/ovgenpy.py
@@ -222,10 +222,17 @@ class Ovgen:
 
         with self._load_outputs():
             prev = -1
+
+            # When subsampling FPS, render frames from the future to alleviate lag.
+            # subfps=1, ahead=0.
+            # subfps=2, ahead=1.
+            render_subfps = self.cfg.render_subfps
+            ahead = render_subfps // 2
+
             # For each frame, render each wave
             for frame in range(begin_frame, end_frame):
                 time_seconds = frame / fps
-                should_render = (frame - begin_frame) % self.cfg.render_subfps == 0
+                should_render = (frame - begin_frame) % render_subfps == ahead
 
                 rounded = int(time_seconds)
                 if PRINT_TIMESTAMP and rounded != prev:

--- a/ovgenpy/ovgenpy.py
+++ b/ovgenpy/ovgenpy.py
@@ -35,15 +35,14 @@ class BenchmarkMode(IntEnum):
 @register_config(always_dump='render_subfps begin_time end_time subsampling')
 class Config:
     master_audio: Optional[str]
+    begin_time: float = 0
+    end_time: float = None
 
     fps: int
     render_subfps: int = 1
     # FFmpeg accepts FPS as a fraction only.
     render_fps = property(lambda self:
                           Fraction(self.fps, self.render_subfps))
-
-    begin_time: float = 0
-    end_time: float = None
 
     width_ms: int
 

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -135,7 +135,30 @@ def test_render_subfps_one():
     """ Ensure video gets rendered when render_subfps=1.
     This test fails if ceildiv is used to calculate `ahead`.
     """
-    pass #TODO
+    from ovgenpy.outputs import IOutputConfig, Output, register_output
+
+    # region DummyOutput
+    class DummyOutputConfig(IOutputConfig):
+        pass
+
+    @register_output(DummyOutputConfig)
+    class DummyOutput(Output):
+        frames_written = 0
+
+        @classmethod
+        def write_frame(cls, frame: bytes) -> None:
+            cls.frames_written += 1
+
+    assert DummyOutput
+    # endregion
+
+    # Create Ovgen with render_subfps=1. Ensure multiple frames are outputted.
+    cfg = sine440_config()
+    cfg.render_subfps = 1
+
+    ovgen = Ovgen(cfg, '.', outputs=[DummyOutputConfig()])
+    ovgen.play()
+    assert DummyOutput.frames_written >= 2
 
 
 def test_render_subfps_non_integer():

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -1,3 +1,4 @@
+from fractions import Fraction
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -161,19 +162,36 @@ def test_render_subfps_one():
     assert DummyOutput.frames_written >= 2
 
 
-def test_render_subfps_non_integer():
+def test_render_subfps_non_integer(mocker: 'pytest_mock.MockFixture'):
     """ Ensure we output non-integer subfps as fractions,
     and that ffmpeg doesn't crash.
     TODO does ffmpeg understand decimals??
     """
 
+    cfg = sine440_config()
+    cfg.fps = 60
+    cfg.render_subfps = 7
 
-def test_render_subfps_ahead():
-    """ Ensure that we render slightly ahead in time when subfps>1,
-    to avoid frames lagging behind audio. """
-# TODO test render subfps
-# including integer and non-integer rations
-#
+    # By default, we output render_fps (ffmpeg -framerate) as a fraction.
+    assert isinstance(cfg.render_fps, Fraction)
+    assert cfg.render_fps != int(cfg.render_fps)
+    assert Fraction(1) == int(1)
+
+    ovgen = Ovgen(cfg, '.', outputs=[NULL_OUTPUT])
+    ovgen.play()
+
+    # But it seems FFmpeg actually allows decimal -framerate (although a bad idea).
+    # from ovgenpy.ovgenpy import Config
+    # render_fps = mocker.patch.object(Config, 'render_fps',
+    #                                  new_callable=mocker.PropertyMock)
+    # render_fps.return_value = 60 / 7
+    # assert isinstance(cfg.render_fps, float)
+    # ovgen = Ovgen(cfg, '.', outputs=[NULL_OUTPUT])
+    # ovgen.play()
+
+
+# Possibility: add a test to ensure that we render slightly ahead in time
+# when subfps>1, to avoid frames lagging behind audio.
 
 
 class DummyException(Exception):

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -120,7 +120,27 @@ def test_ovgen_terminate_works():
 
 # TODO integration test without audio
 
-# TODO integration test on ???
+
+def test_render_subfps_one():
+    """ Ensure video gets rendered when render_subfps=1.
+    This test fails if ceildiv is used to calculate `ahead`.
+    """
+    pass #TODO
+
+
+def test_render_subfps_non_integer():
+    """ Ensure we output non-integer subfps as fractions,
+    and that ffmpeg doesn't crash.
+    TODO does ffmpeg understand decimals??
+    """
+
+
+def test_render_subfps_ahead():
+    """ Ensure that we render slightly ahead in time when subfps>1,
+    to avoid frames lagging behind audio. """
+# TODO test render subfps
+# including integer and non-integer rations
+#
 
 
 class DummyException(Exception):

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -74,15 +74,20 @@ def test_terminate_ffplay(Popen):
             popen.terminate.assert_called()
 
 
+def sine440_config(master_audio=True):
+    kwargs = dict(channels=[ChannelConfig('tests/sine440.wav')])
+    if master_audio:
+        kwargs.update(master_audio='tests/sine440.wav')
+    cfg = default_config(**kwargs)
+    return cfg
+
+
 @pytest.mark.usefixtures('Popen')
 def test_ovgen_terminate_ffplay(Popen, mocker: 'pytest_mock.MockFixture'):
     """ Integration test: Ensure ovgenpy calls terminate() on ffmpeg and ffplay when
     Python exceptions occur. """
 
-    cfg = default_config(
-        channels=[ChannelConfig('tests/sine440.wav')],
-        master_audio='tests/sine440.wav',
-    )
+    cfg = sine440_config()
     ovgen = Ovgen(cfg, '.', outputs=[FFplayOutputConfig()])
 
     render_frame = mocker.patch.object(MatplotlibRenderer, 'render_frame')
@@ -102,13 +107,10 @@ def test_ovgen_terminate_works():
     """ Ensure that ffmpeg/ffplay terminate quickly after Python exceptions, when
     `popen.terminate()` is called. """
 
-    cfg = default_config(
-        channels=[ChannelConfig('tests/sine440.wav')],
-        master_audio='tests/sine440.wav',
-        outputs=[FFplayOutputConfig()],
-        end_time=0.5,   # Reduce test duration
-    )
-    ovgen = Ovgen(cfg, '.')  # TODO fix skipped ffplay test
+    cfg = sine440_config()
+    cfg.end_time = 0.5  # Reduce test duration
+
+    ovgen = Ovgen(cfg, '.', outputs=[FFplayOutputConfig()])
     ovgen.raise_on_teardown = DummyException
 
     with pytest.raises(DummyException):


### PR DESCRIPTION
- All frames are triggered, but only 1 in `render_subfps` frames are rendered.
- When subsampling FPS, render frames from the future to alleviate lag 
- Reorder Config, move `fps` and `render_subfps` closer to `render_subsampling` (easier to use for me)
- Simplify output-related test code