### PR TITLE
 Allow per-channel triggers to inherit from global (if untyped dicts)

### DIFF
--- a/ovgenpy/channel.py
+++ b/ovgenpy/channel.py
@@ -17,6 +17,7 @@ if TYPE_CHECKING:
 class ChannelConfig:
     wav_path: str
 
+    # Supplying a dict inherits attributes from global trigger.
     trigger: Union[ITriggerConfig, dict, None] = None    # TODO test channel-specific triggers
     # Multiplies how wide the window is, in milliseconds.
     trigger_width: Optional[int] = None

--- a/ovgenpy/channel.py
+++ b/ovgenpy/channel.py
@@ -1,13 +1,14 @@
 from os.path import abspath
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, Optional, Union
 
-from ovgenpy.config import register_config, Alias
+import attr
+
+from ovgenpy.config import register_config, Alias, OvgenError
+from ovgenpy.triggers import ITriggerConfig
 from ovgenpy.util import coalesce
 from ovgenpy.wave import _WaveConfig, Wave
 
-
 if TYPE_CHECKING:
-    from ovgenpy.triggers import ITriggerConfig
     from ovgenpy.ovgenpy import Config
 
 
@@ -15,7 +16,7 @@ if TYPE_CHECKING:
 class ChannelConfig:
     wav_path: str
 
-    trigger: Optional['ITriggerConfig'] = None    # TODO test channel-specific triggers
+    trigger: Union[ITriggerConfig, dict, None] = None    # TODO test channel-specific triggers
     # Multiplies how wide the window is, in milliseconds.
     trigger_width: Optional[int] = None
     render_width: Optional[int] = None
@@ -65,7 +66,17 @@ class Channel:
         self.render_stride = rsub * rw
 
         # Create a Trigger object.
-        tcfg = cfg.trigger or ovgen_cfg.trigger
+        if isinstance(cfg.trigger, ITriggerConfig):
+            tcfg = cfg.trigger
+        elif isinstance(cfg.trigger, dict):
+            tcfg = attr.evolve(ovgen_cfg.trigger, **cfg.trigger)
+        elif cfg.trigger is None:
+            tcfg = ovgen_cfg.trigger
+        else:
+            raise OvgenError(
+                f'invalid per-channel trigger {cfg.trigger}, type={type(cfg.trigger)}, '
+                f'must be (*)TriggerConfig, dict, or None')
+
         self.trigger = tcfg(
             wave=self.wave,
             tsamp=trigger_samp,

--- a/ovgenpy/channel.py
+++ b/ovgenpy/channel.py
@@ -2,6 +2,7 @@ from os.path import abspath
 from typing import TYPE_CHECKING, Optional, Union
 
 import attr
+from ruamel.yaml.comments import CommentedMap
 
 from ovgenpy.config import register_config, Alias, OvgenError
 from ovgenpy.triggers import ITriggerConfig
@@ -68,7 +69,7 @@ class Channel:
         # Create a Trigger object.
         if isinstance(cfg.trigger, ITriggerConfig):
             tcfg = cfg.trigger
-        elif isinstance(cfg.trigger, dict):
+        elif isinstance(cfg.trigger, (CommentedMap, dict)):  # CommentedMap may/not be subclass of dict.
             tcfg = attr.evolve(ovgen_cfg.trigger, **cfg.trigger)
         elif cfg.trigger is None:
             tcfg = ovgen_cfg.trigger

--- a/ovgenpy/config.py
+++ b/ovgenpy/config.py
@@ -27,10 +27,8 @@ class MyYAML(YAML):
 
 
 # Default typ='roundtrip' creates 'ruamel.yaml.comments.CommentedMap' instead of dict.
-# Problem: not isinstance(CommentedMap, dict).
-# Solution: typ='safe' (is faster as well).
-# TODO write test for loading Channel.trigger = dict from YAML
-yaml = MyYAML(typ='safe')
+# Is isinstance(CommentedMap, dict)? IDK
+yaml = MyYAML()
 _yaml_loadable = yaml_object(yaml)
 
 

--- a/ovgenpy/config.py
+++ b/ovgenpy/config.py
@@ -26,11 +26,11 @@ class MyYAML(YAML):
             return stream.getvalue()
 
 
-# https://yaml.readthedocs.io/en/latest/dumpcls.html
-# >Only yaml = YAML(typ='unsafe') loads and dumps Python objects out-of-the-box. And
-# >since it loads any Python object, this can be unsafe.
-# I assume roundtrip is safe.
-yaml = MyYAML()
+# Default typ='roundtrip' creates 'ruamel.yaml.comments.CommentedMap' instead of dict.
+# Problem: not isinstance(CommentedMap, dict).
+# Solution: typ='safe' (is faster as well).
+# TODO write test for loading Channel.trigger = dict from YAML
+yaml = MyYAML(typ='safe')
 _yaml_loadable = yaml_object(yaml)
 
 


### PR DESCRIPTION
New trigger:

```yaml
trigger: !CorrelationTriggerConfig
  edge_strength: -0.1
  responsiveness: 1
  buffer_falloff: 0.5
  use_edge_trigger: false
```

Inherit:

```yaml
trigger:
  edge_strength: -1
```

------

- [ ] add unit tests for channel trigger