### PR TITLE
Make always-dumped CorrelationTriggerConfig attributes required

### DIFF
--- a/ovgenpy/ovgenpy.py
+++ b/ovgenpy/ovgenpy.py
@@ -134,6 +134,7 @@ def default_config(**kwargs) -> Config:
         trigger=CorrelationTriggerConfig(
             edge_strength=2,
             responsiveness=0.5,
+            buffer_falloff=0.5,
             use_edge_trigger=False,
             # Removed due to speed hit.
             # post=LocalPostTriggerConfig(strength=0.1),

--- a/ovgenpy/triggers.py
+++ b/ovgenpy/triggers.py
@@ -110,7 +110,7 @@ class PerFrameCache:
 ''')
 class CorrelationTriggerConfig(ITriggerConfig):
     # get_trigger
-    edge_strength: float = 10.0
+    edge_strength: float
     trigger_diameter: float = 0.5
 
     trigger_falloff: Tuple[float, float] = (4.0, 1.0)
@@ -118,16 +118,13 @@ class CorrelationTriggerConfig(ITriggerConfig):
     lag_prevention: float = 0.25
 
     # _update_buffer
-    responsiveness: float = 0.1
-    buffer_falloff: float = 0.5  # Gaussian std = wave_period * buffer_falloff
+    responsiveness: float
+    buffer_falloff: float  # Gaussian std = wave_period * buffer_falloff
 
     # region Legacy Aliases
     trigger_strength = Alias('edge_strength')
     falloff_width = Alias('buffer_falloff')
-
-    # Problem: InitVar with default values are (wrongly) accessible on object instances.
-    # use_edge_trigger is False but self.use_edge_trigger is True, wtf?
-    use_edge_trigger: bool = True
+    use_edge_trigger: bool
     # endregion
 
     def __attrs_post_init__(self):

--- a/ovgenpy/triggers.py
+++ b/ovgenpy/triggers.py
@@ -102,12 +102,7 @@ class PerFrameCache:
 
 # CorrelationTrigger
 
-@kw_config(always_dump='''
-    use_edge_trigger
-    edge_strength
-    responsiveness
-    buffer_falloff
-''')
+@kw_config
 class CorrelationTriggerConfig(ITriggerConfig):
     # get_trigger
     edge_strength: float

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -27,6 +27,7 @@ def call_main(argv):
 
 @pytest.fixture
 def yaml_sink(mocker: 'pytest_mock.MockFixture') -> Callable:
+    """ Mocks yaml.dump() and returns call args. Does not test dumping to string. """
     def _yaml_sink(command):
         dump = mocker.patch.object(yaml, 'dump')
 

--- a/tests/test_trigger.py
+++ b/tests/test_trigger.py
@@ -1,3 +1,4 @@
+import attr
 import matplotlib.pyplot as plt
 import pytest
 from matplotlib.axes import Axes
@@ -11,13 +12,21 @@ from ovgenpy.wave import Wave
 triggers.SHOW_TRIGGER = False
 
 
+def cfg_template(**kwargs) -> CorrelationTriggerConfig:
+    """ Not identical to default_config() template. """
+    cfg = CorrelationTriggerConfig(
+        edge_strength=2,
+        responsiveness=1,
+        buffer_falloff=0.5,
+        use_edge_trigger=False,
+    )
+    return attr.evolve(cfg, **kwargs)
+
+
 @pytest.fixture(scope='session', params=[False, True])
 def cfg(request):
     use_edge_trigger = request.param
-    return CorrelationTriggerConfig(
-        use_edge_trigger=use_edge_trigger,
-        responsiveness=1,
-    )
+    return cfg_template(use_edge_trigger=use_edge_trigger)
 
 
 @pytest.fixture(scope='session', params=[
@@ -27,11 +36,7 @@ def cfg(request):
 ])
 def post_cfg(request):
     post = request.param
-    return CorrelationTriggerConfig(
-        use_edge_trigger=False,
-        responsiveness=1,
-        post=post
-    )
+    return cfg_template(post=post)
 
 
 # I regret adding the nsamp_frame parameter. It makes unit tests hard.
@@ -149,7 +154,7 @@ def test_trigger_stride_edges(cfg: CorrelationTriggerConfig):
 
 
 def test_trigger_should_recalc_window():
-    cfg = CorrelationTriggerConfig(recalc_semitones=1.0)
+    cfg = cfg_template(recalc_semitones=1.0)
     wave = Wave(None, 'tests/sine440.wav')
     trigger: CorrelationTrigger = cfg(wave, tsamp=1000, stride=1, fps=FPS)
 


### PR DESCRIPTION
- Move `buffer_falloff` to `default_config()`.
- Edit `test_trigger.py` by adding a custom `CorrelationTriggerConfig` template.
    - This template is *very different* from the previous `CorrelationTriggerConfig` optional-defaults. The tests pass anyway.